### PR TITLE
Add Github Action to publish to gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Publish to Github Pages
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+   # This workflow contains a single job called "deploy"
+  deploy:
+    name: Deploy to gh-pages
+    # The type of runner that the job will run onruns-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install # will run `yarn install` command
+      - uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: deploy # will run `yarn build` command
+      - name: Success
+        run: echo "Successfully deployed to gh-pages branch"


### PR DESCRIPTION
This should provide automated publishing of new versions of the Github Pages app without needing to run `yarn deploy` locally.